### PR TITLE
docs: describe Redis cache in architecture

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -14,6 +14,9 @@ The project enables Retrieval-Augmented Generation using a web client, an API se
 - **FastAPI Server**
   - Receives prompts, orchestrates retrieval and generation, and exposes REST endpoints.
   - Adheres to `python-api-dev-rules.mdc`.
+- **Redis Cache**
+  - Caches recent vector queries and user data to reduce database load.
+  - Runs in a dedicated Docker container.
 - **Qdrant Vector Store**
   - Stores document embeddings for context retrieval.
   - Runs in a dedicated Docker container.
@@ -25,9 +28,10 @@ The project enables Retrieval-Augmented Generation using a web client, an API se
 
 ## Data Flow
 1. The Next.js client sends a user prompt to the FastAPI server.
-2. The server queries Qdrant for relevant vectors and retrieves user data from PostgreSQL.
-3. The server constructs an augmented prompt and forwards it to the LM Studio host.
-4. The generated response is returned to the client and stored in PostgreSQL.
+2. The server checks Redis for relevant vectors and user data.
+3. On a cache miss, it queries Qdrant for vectors and PostgreSQL for user data.
+4. The server constructs an augmented prompt and forwards it to the LM Studio host.
+5. The generated response is returned to the client, stored in PostgreSQL, and cached in Redis.
 
 ## Deployment
-All services are containerized. Qdrant and PostgreSQL run in separate Docker containers, the FastAPI server connects to the LM Studio host, and the Next.js client interacts with the server over HTTP.
+All services are containerized. Qdrant, PostgreSQL, and Redis run in separate Docker containers; Redis is configured with a persistent volume and environment variables for host and port. The FastAPI server connects to the LM Studio host, and the Next.js client interacts with the server over HTTP.


### PR DESCRIPTION
## Summary
- document Redis cache component used by FastAPI server
- note cache lookup before falling back to Qdrant/PostgreSQL
- update deployment notes to include Redis container configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2e2a799a483218ef304856aa00531