### PR TITLE
docs: separate redis cache and broker

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -17,13 +17,16 @@ The project enables Retrieval-Augmented Generation using a Next.js web client, a
   - Follows the guidelines in `net-dev-rules.mdc`.
 - **Message Broker**
   - Dispatches tasks between the ASP.NET Core MVC server and background workers.
-  - Supports Redis or RabbitMQ backends running in their own containers.
+  - Uses a dedicated Redis instance running in its own container (`redis-broker`).
+  - Connection settings are supplied via `BROKER_REDIS_URL` (e.g., `redis://redis-broker:6379/0`).
+  - RabbitMQ can replace the Redis broker if required.
 - **Background Worker Service**
   - Implemented in C# as a .NET background worker using Hangfire or a custom `IHostedService`.
   - Consumes queued prompts from the message broker, updates task status, and persists results.
 - **Redis Cache**
   - Caches recent vector queries and user data to reduce database load.
-  - Runs in a dedicated Docker container.
+  - Uses a separate Redis instance in the `redis-cache` container.
+  - Clients connect using `CACHE_REDIS_URL` (e.g., `redis://redis-cache:6379/0`).
 - **Qdrant Vector Store**
   - Stores document embeddings for context retrieval.
   - Runs in a dedicated Docker container.
@@ -48,10 +51,11 @@ The project enables Retrieval-Augmented Generation using a Next.js web client, a
 7. The generated response is stored in PostgreSQL, cached in Redis, and later retrieved by the client using the task identifier.
 
 ## Deployment
-All services are containerized. Qdrant, PostgreSQL, Redis, the message broker, and the background worker service run in separate Docker containers.
+All services are containerized. Qdrant, PostgreSQL, the Redis cache, the Redis broker, and the background worker service run in separate Docker containers.
 A Docker Compose configuration orchestrates these services for local development, while Kubernetes deployments enable scaling individual services in production through replicas and service discovery.
-Redis is configured with a persistent volume and environment variables for host and port.
-For task distribution, deploy a broker such as Redis or RabbitMQ and point the ASP.NET Core MVC server and .NET worker containers to it via environment variables.
+Two Redis instances are provisioned: `redis-cache` for application caching and `redis-broker` for Hangfire or task queues. Each exposes port `6379` and maintains its own volume for persistence.
+The ASP.NET Core MVC server and worker read `CACHE_REDIS_URL` to connect to `redis-cache` and `BROKER_REDIS_URL` to connect to `redis-broker`.
+If RabbitMQ is preferred for task distribution, the `BROKER_REDIS_URL` setting is replaced by the appropriate RabbitMQ connection string.
 The ASP.NET Core MVC server connects to the LM Studio host and enqueues jobs to the broker, while workers consume them.
 The ASP.NET Core MVC tier can be replicated behind a load balancer (e.g., Nginx, Traefik, or a cloud provider gateway) to evenly distribute API requests and increase availability.
 The Next.js client interacts with the server over HTTP and can be horizontally scaled by running multiple stateless instances behind a CDN or load balancer.


### PR DESCRIPTION
## Summary
- document dedicated Redis instances for broker and cache
- add connection details for `redis-broker` and `redis-cache` containers

## Testing
- `npm test` (fails: missing package.json)
- `dotnet test` (fails: no project or solution file)

------
https://chatgpt.com/codex/tasks/task_e_68a3463472a483218b4dbb3bb3fde22c