### PR TITLE
docs: promote auth and monitoring components

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -34,17 +34,18 @@ The project enables Retrieval-Augmented Generation using a Next.js web client, a
 - **PostgreSQL Database**
   - Persists user credentials, chat history, and preferences.
   - Follows the conventions in `sql-style-guide.mdc` and runs in Docker.
-
-### Coordinated PostgreSQL Access
-- **Migration ownership**: The ASP.NET Core stack generates and runs migrations via EF Core. CI/CD executes `dotnet ef database update` before deploying services.
-- **Model synchronization**: After migrations, the Next.js layer refreshes its schema with `prisma db pull` to regenerate the Prisma client.
-- **Concurrency and isolation**: Both layers use optimistic concurrency with a `row_version`/`version` column and operate at the `READ COMMITTED` isolation level.
-- **Transactions**: Multi-statement operations wrap writes in transactions—`prisma.$transaction` in Next.js and `DbContext.Database.BeginTransaction` or `TransactionScope` in ASP.NET Core.
 - **Authentication/Authorization Service**
   - Issues and verifies JWTs to manage user identity and permissions.
 - **Monitoring Stack**
   - Collects metrics and provides dashboards via Prometheus and Grafana.
   - Alerts on system health for proactive maintenance.
+
+### Coordinated PostgreSQL Access
+Both the ASP.NET Core and Next.js layers follow these practices when interacting with PostgreSQL:
+- **Migration ownership**: The ASP.NET Core stack generates and runs migrations via EF Core. CI/CD executes `dotnet ef database update` before deploying services.
+- **Model synchronization**: After migrations, the Next.js layer refreshes its schema with `prisma db pull` to regenerate the Prisma client.
+- **Concurrency and isolation**: Both layers use optimistic concurrency with a `row_version`/`version` column and operate at the `READ COMMITTED` isolation level.
+- **Transactions**: Multi-statement operations wrap writes in transactions—`prisma.$transaction` in Next.js and `DbContext.Database.BeginTransaction` or `TransactionScope` in ASP.NET Core.
 
 ## Data Flow
 1. The Next.js client sends a user prompt to the ASP.NET Core MVC server.


### PR DESCRIPTION
## Summary
- move auth and monitoring services to top-level components
- clarify coordinated PostgreSQL access practices

## Testing
- `npm test` (fails: Could not read package.json)
- `dotnet test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a35811d5848321b2bfdcdf458834c0