### PR TITLE
Remove Hangfire mention from architecture

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -20,8 +20,8 @@ The project enables Retrieval-Augmented Generation using a Next.js web client, a
   - Uses a RabbitMQ instance running in its own container (`rabbitmq-broker`) and the MassTransit library for queue management.
   - Connection settings are supplied via `BROKER_RABBITMQ_URL` (e.g., `amqp://rabbitmq-broker:5672`).
 - **Background Worker Service**
-  - Implemented in C# as a .NET background worker using Hangfire and MassTransit.
-  - Consumes queued prompts from RabbitMQ via MassTransit, updates task status, and persists results.
+  - Implemented in C# as a .NET background worker that uses MassTransit to consume jobs from RabbitMQ.
+  - Handles task status and result persistence directly through the broker; Hangfire is not employed for scheduling or storage.
 - **Redis Cache**
   - Caches recent vector queries and user data to reduce database load.
   - Uses a separate Redis instance in the `redis-cache` container.


### PR DESCRIPTION
## Summary
- clarify that background worker uses MassTransit with RabbitMQ for job handling
- note that Hangfire is not used for scheduling or persistence

## Testing
- `npm test` *(fails: could not read package.json)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a362f1d3588321bcddb3d798d38f63