### PR TITLE
docs: add LM_HOST_URL config for LM Studio

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -31,6 +31,7 @@ The project enables Retrieval-Augmented Generation using a Next.js web client, a
   - Runs in a dedicated Docker container.
 - **LM Studio Host**
   - Serves language models that generate responses.
+  - Clients connect using `LM_HOST_URL` (e.g., `http://lm-studio-host:8080`).
 - **PostgreSQL Database**
   - Persists user credentials, chat history, and preferences.
   - Follows the conventions in `sql-style-guide.mdc` and runs in Docker.


### PR DESCRIPTION
## Summary
- document LM_HOST_URL environment variable for connecting to the LM Studio host

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3657db4e48321a4bc74da967939f3