### PR TITLE
docs: add connection env vars for qdrant and postgres

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -29,12 +29,14 @@ The project enables Retrieval-Augmented Generation using a Next.js web client, a
 - **Qdrant Vector Store**
   - Stores document embeddings for context retrieval.
   - Runs in a dedicated Docker container.
+  - Clients connect using `QDRANT_URL` (e.g., `http://qdrant:6333`).
 - **LM Studio Host**
   - Serves language models that generate responses.
   - Clients connect using `LM_HOST_URL` (e.g., `http://lm-studio-host:8080`).
 - **PostgreSQL Database**
   - Persists user credentials, chat history, and preferences.
   - Follows the conventions in `sql-style-guide.mdc` and runs in Docker.
+  - Services connect using `POSTGRES_URL` (e.g., `postgresql://postgres:postgres@postgres-db:5432/app`).
 - **Authentication/Authorization Service**
   - Provides login endpoints that validate user credentials against PostgreSQL.
   - Issues short-lived JWTs with user ID and role claims after successful authentication.
@@ -67,7 +69,7 @@ A Docker Compose configuration orchestrates these containers for local developme
 Both orchestrators expose the containers on a shared network so the client can reach the server and backend services.
 A Redis instance named `redis-cache` handles application caching, while a RabbitMQ instance (`rabbitmq-broker`) manages task queues. `redis-cache` exposes port `6379`, and `rabbitmq-broker` exposes port `5672`.
 The authentication service runs in an `auth-service` container that exposes HTTP endpoints and signs tokens using `AUTH_JWT_SECRET` or mounted keys. Clients and servers reach it via `AUTH_SERVICE_URL`.
-The ASP.NET Core MVC server and worker read `CACHE_REDIS_URL` to connect to `redis-cache` and `BROKER_RABBITMQ_URL` for MassTransit to connect to `rabbitmq-broker`.
+The ASP.NET Core MVC server and worker read `CACHE_REDIS_URL` to connect to `redis-cache`, `BROKER_RABBITMQ_URL` for MassTransit to connect to `rabbitmq-broker`, `QDRANT_URL` for the vector store, and `POSTGRES_URL` for PostgreSQL.
 The ASP.NET Core MVC server connects to the LM Studio host and enqueues jobs to the broker via MassTransit, while workers consume them through MassTransit. The server validates JWTs locally using the shared secret or by calling the auth service's introspection endpoint.
 The ASP.NET Core MVC tier can be replicated behind a load balancer (e.g., Nginx, Traefik, or a cloud provider gateway) to evenly distribute API requests and increase availability.
 The Next.js client interacts with the server over HTTP and can be horizontally scaled by running multiple stateless instances behind a CDN or load balancer.


### PR DESCRIPTION
## Summary
- document `QDRANT_URL` for connecting to the Qdrant vector store
- document `POSTGRES_URL` for PostgreSQL connections
- note these environment variables in the deployment section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a36a73bfc48321af6173c4947ebe60