### PR TITLE
Add data flow diagrams

### DIFF
--- a/diagrams/profile_update_flow.md
+++ b/diagrams/profile_update_flow.md
@@ -1,0 +1,11 @@
+```mermaid
+graph TD
+    User-->Client[Next.js Client]
+    Client-- Request JWT -->Auth[Auth Service]
+    Auth-- Signed JWT -->Client
+    Client-- Profile update + JWT -->Api[ASP.NET Core MVC Server]
+    Api-- Validate & write -->Postgres[PostgreSQL]
+    Api-- Update cache -->Redis[Redis Cache]
+    Api-- Acknowledge update -->Client
+    Client-->User
+```

--- a/diagrams/profile_update_flow.mmd
+++ b/diagrams/profile_update_flow.mmd
@@ -1,0 +1,9 @@
+graph TD
+    User-->Client[Next.js Client]
+    Client-- Request JWT -->Auth[Auth Service]
+    Auth-- Signed JWT -->Client
+    Client-- Profile update + JWT -->Api[ASP.NET Core MVC Server]
+    Api-- Validate & write -->Postgres[PostgreSQL]
+    Api-- Update cache -->Redis[Redis Cache]
+    Api-- Acknowledge update -->Client
+    Client-->User

--- a/diagrams/prompt_flow.md
+++ b/diagrams/prompt_flow.md
@@ -1,0 +1,19 @@
+```mermaid
+graph TD
+    User-->Client[Next.js Client]
+    Client-- Request JWT -->Auth[Auth Service]
+    Auth-- Signed JWT -->Client
+    Client-- Prompt + JWT -->Api[ASP.NET Core MVC Server]
+    Api-- Enqueue prompt -->Broker[RabbitMQ]
+    Broker-- Deliver task -->Worker[Background Worker]
+    Worker-- Check cache -->Redis[Redis Cache]
+    Worker-- Query vectors -->Qdrant[Qdrant Vector DB]
+    Worker-- Query user data -->Postgres[PostgreSQL]
+    Worker-- Augment prompt & send -->LM[LM Studio]
+    LM-- Generated answer -->Worker
+    Worker-- Store answer -->Postgres
+    Worker-- Cache answer -->Redis
+    Worker-- Signal completion -->Api
+    Api-- Task result -->Client
+    Client-->User
+```

--- a/diagrams/prompt_flow.mmd
+++ b/diagrams/prompt_flow.mmd
@@ -1,0 +1,17 @@
+graph TD
+    User-->Client[Next.js Client]
+    Client-- Request JWT -->Auth[Auth Service]
+    Auth-- Signed JWT -->Client
+    Client-- Prompt + JWT -->Api[ASP.NET Core MVC Server]
+    Api-- Enqueue prompt -->Broker[RabbitMQ]
+    Broker-- Deliver task -->Worker[Background Worker]
+    Worker-- Check cache -->Redis[Redis Cache]
+    Worker-- Query vectors -->Qdrant[Qdrant Vector DB]
+    Worker-- Query user data -->Postgres[PostgreSQL]
+    Worker-- Augment prompt & send -->LM[LM Studio]
+    LM-- Generated answer -->Worker
+    Worker-- Store answer -->Postgres
+    Worker-- Cache answer -->Redis
+    Worker-- Signal completion -->Api
+    Api-- Task result -->Client
+    Client-->User


### PR DESCRIPTION
## Summary
- Add Mermaid diagram showing prompt-to-LM data flow
- Add Mermaid diagram for user profile update flow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a47076c37c83219512eeaf201211ea