### PR TITLE
docs: clarify API server URL

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@ This roadmap outlines steps to implement the Retrieval-Augmented Generation plat
 
 ## Phase 5: Client App
 - Build a ChatGPT-style interface in the `rag-client-app` container.
-- Authenticate via the auth service and send prompts to the API server using `AUTH_SERVICE_URL`.
+- Authenticate via the auth service and send prompts to the API server using `WEB_SERVICE_URL`.
 - Poll for task status using the returned task identifier.
 
 ## Phase 6: Monitoring Stack


### PR DESCRIPTION
## Summary
- direct client app to call API server via `WEB_SERVICE_URL`

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d3ad43448321bbb6bb4fe6568c08