### PR TITLE
Use email for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Store a custom knowledge as vector embeddings
    ```sql
    CREATE TABLE users (
        id SERIAL PRIMARY KEY,
-       username TEXT NOT NULL UNIQUE,
+       email TEXT NOT NULL UNIQUE,
        password_hash TEXT NOT NULL
    );
    ```
@@ -41,8 +41,8 @@ Store a custom knowledge as vector embeddings
    ```
 4. Insert a user (generate the password hash with your preferred BCrypt tool):
    ```sql
-   INSERT INTO users (username, password_hash)
-   VALUES ('alice', '$2b$12$...bcrypt_hash_here...');
+   INSERT INTO users (email, password_hash)
+   VALUES ('alice@example.com', '$2b$12$...bcrypt_hash_here...');
    ```
 
 ## Running

--- a/rag-auth-service/Controllers/AuthController.cs
+++ b/rag-auth-service/Controllers/AuthController.cs
@@ -27,8 +27,8 @@ public class AuthController : ControllerBase
         await using var conn = new NpgsqlConnection(connString);
         await conn.OpenAsync();
 
-        await using var cmd = new NpgsqlCommand("SELECT id, username, password_hash FROM users WHERE username = @u", conn);
-        cmd.Parameters.AddWithValue("u", request.Username);
+        await using var cmd = new NpgsqlCommand("SELECT id, email, password_hash FROM users WHERE email = @e", conn);
+        cmd.Parameters.AddWithValue("e", request.Email);
         await using var reader = await cmd.ExecuteReaderAsync();
         if (!await reader.ReadAsync())
             return Unauthorized();
@@ -38,8 +38,8 @@ public class AuthController : ControllerBase
         if (!BCrypt.Net.BCrypt.Verify(request.Password, user.PasswordHash))
             return Unauthorized();
 
-        var access = _tokenService.GenerateAccessToken(user.Id.ToString(), user.Username);
-        var refresh = _tokenService.GenerateRefreshToken(user.Id.ToString(), user.Username);
+        var access = _tokenService.GenerateAccessToken(user.Id.ToString(), user.Email);
+        var refresh = _tokenService.GenerateRefreshToken(user.Id.ToString(), user.Email);
         return Ok(new TokenResponse(access, refresh, 900));
     }
 
@@ -55,12 +55,12 @@ public class AuthController : ControllerBase
             return Unauthorized();
 
         var userId = principal.FindFirstValue(JwtRegisteredClaimNames.Sub);
-        var username = principal.FindFirstValue(JwtRegisteredClaimNames.UniqueName) ?? principal.Identity?.Name;
-        if (userId is null || username is null)
+        var email = principal.FindFirstValue(JwtRegisteredClaimNames.Email);
+        if (userId is null || email is null)
             return Unauthorized();
 
-        var access = _tokenService.GenerateAccessToken(userId, username);
-        var refresh = _tokenService.GenerateRefreshToken(userId, username);
+        var access = _tokenService.GenerateAccessToken(userId, email);
+        var refresh = _tokenService.GenerateRefreshToken(userId, email);
         return Ok(new TokenResponse(access, refresh, 900));
     }
 
@@ -77,7 +77,7 @@ public class AuthController : ControllerBase
         {
             active,
             sub = principal.FindFirstValue(JwtRegisteredClaimNames.Sub),
-            username = principal.FindFirstValue(JwtRegisteredClaimNames.UniqueName)
+            email = principal.FindFirstValue(JwtRegisteredClaimNames.Email)
         });
     }
 }

--- a/rag-auth-service/Models/AuthModels.cs
+++ b/rag-auth-service/Models/AuthModels.cs
@@ -1,7 +1,7 @@
 namespace RagAuthService.Models;
 
-public record LoginRequest(string Username, string Password);
+public record LoginRequest(string Email, string Password);
 public record TokenResponse(string AccessToken, string RefreshToken, int ExpiresIn);
 public record RefreshRequest(string RefreshToken);
 public record IntrospectRequest(string Token);
-public record User(int Id, string Username, string PasswordHash);
+public record User(int Id, string Email, string PasswordHash);

--- a/rag-auth-service/Services/TokenService.cs
+++ b/rag-auth-service/Services/TokenService.cs
@@ -16,22 +16,22 @@ public class TokenService
 
     private SymmetricSecurityKey GetSigningKey() => new(Encoding.UTF8.GetBytes(_secret));
 
-    public string GenerateAccessToken(string userId, string username)
+    public string GenerateAccessToken(string userId, string email)
     {
         var claims = new[]
         {
             new Claim(JwtRegisteredClaimNames.Sub, userId),
-            new Claim(JwtRegisteredClaimNames.UniqueName, username)
+            new Claim(JwtRegisteredClaimNames.Email, email)
         };
         return GenerateToken(claims, DateTime.UtcNow.AddMinutes(15));
     }
 
-    public string GenerateRefreshToken(string userId, string username)
+    public string GenerateRefreshToken(string userId, string email)
     {
         var claims = new[]
         {
             new Claim(JwtRegisteredClaimNames.Sub, userId),
-            new Claim(JwtRegisteredClaimNames.UniqueName, username),
+            new Claim(JwtRegisteredClaimNames.Email, email),
             new Claim("typ", "refresh")
         };
         return GenerateToken(claims, DateTime.UtcNow.AddDays(7));


### PR DESCRIPTION
## Summary
- authenticate users by email instead of username
- issue JWTs with email claims
- document email field in user table setup

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68aa307aff908321985e36381376b4cb