### PR TITLE
feat: add web service with rabbitmq and jwt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,21 @@ services:
     networks:
       - rag-net
 
+  rag-web-service:
+    build: ./rag-web-service
+    env_file: .env
+    environment:
+      - MESSAGE_BROKER_URL=${MESSAGE_BROKER_URL}
+      - AUTH_SERVICE_URL=${AUTH_SERVICE_URL}
+      - JWT_SECRET=${JWT_SECRET}
+    depends_on:
+      - rag-message-broker
+      - rag-auth-service
+    ports:
+      - "5002:8080"
+    networks:
+      - rag-net
+
 volumes:
   db-data:
   vector-data:

--- a/rag-web-service/Controllers/PromptsController.cs
+++ b/rag-web-service/Controllers/PromptsController.cs
@@ -1,0 +1,35 @@
+using MassTransit;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using RagWebService.Models;
+
+namespace RagWebService.Controllers;
+
+[ApiController]
+[Route("prompts")]
+public class PromptsController : ControllerBase
+{
+    private readonly IPublishEndpoint _publisher;
+
+    public PromptsController(IPublishEndpoint publisher)
+    {
+        _publisher = publisher;
+    }
+
+    [HttpPost]
+    [Authorize]
+    public async Task<IActionResult> SubmitPrompt([FromBody] PromptRequest request)
+    {
+        var taskId = Guid.NewGuid().ToString();
+        await _publisher.Publish(new { TaskId = taskId, Prompt = request.Prompt });
+        return Accepted(new { taskId });
+    }
+
+    [HttpGet("{id}")]
+    [Authorize]
+    public IActionResult GetResult(string id)
+    {
+        // Placeholder for result retrieval logic
+        return NotFound();
+    }
+}

--- a/rag-web-service/Dockerfile
+++ b/rag-web-service/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["RagWebService.csproj", "./"]
+RUN dotnet restore "RagWebService.csproj"
+COPY . .
+RUN dotnet publish "RagWebService.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENV ASPNETCORE_URLS=http://+:8080
+ENTRYPOINT ["dotnet", "RagWebService.dll"]

--- a/rag-web-service/Models/PromptRequest.cs
+++ b/rag-web-service/Models/PromptRequest.cs
@@ -1,0 +1,3 @@
+namespace RagWebService.Models;
+
+public record PromptRequest(string Prompt);

--- a/rag-web-service/Program.cs
+++ b/rag-web-service/Program.cs
@@ -1,0 +1,53 @@
+using System.Text;
+using MassTransit;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var configuration = builder.Configuration;
+
+var jwtSecret = configuration["JWT_SECRET"] ?? throw new InvalidOperationException("JWT_SECRET not configured");
+var brokerUrl = configuration["MESSAGE_BROKER_URL"] ?? throw new InvalidOperationException("MESSAGE_BROKER_URL not configured");
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = false,
+            ValidateAudience = false,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSecret)),
+            ClockSkew = TimeSpan.Zero
+        };
+    });
+
+builder.Services.AddMassTransit(x =>
+{
+    x.UsingRabbitMq((context, cfg) =>
+    {
+        cfg.Host(brokerUrl);
+    });
+});
+
+builder.Services.AddAuthorization();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/rag-web-service/RagWebService.csproj
+++ b/rag-web-service/RagWebService.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.19" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="MassTransit" Version="8.2.4" />
+    <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.4" />
+  </ItemGroup>
+</Project>

--- a/rag-web-service/appsettings.Development.json
+++ b/rag-web-service/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/rag-web-service/appsettings.json
+++ b/rag-web-service/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- scaffold rag-web-service with JWT auth and RabbitMQ publishing
- add prompts controller to enqueue tasks
- update docker-compose to include web service container

## Testing
- `dotnet restore rag-web-service`
- `dotnet build rag-web-service`
- `dotnet restore rag-auth-service`
- `dotnet build rag-auth-service`


------
https://chatgpt.com/codex/tasks/task_e_68ac9cda08088321bebdd8761ccaaa77