### PR TITLE
docs: add swagger descriptions

### DIFF
--- a/rag-auth-service/Controllers/AuthController.cs
+++ b/rag-auth-service/Controllers/AuthController.cs
@@ -4,11 +4,13 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using Npgsql;
 using RagAuthService.Models;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace RagAuthService.Controllers;
 
 [ApiController]
 [Route("auth")]
+[SwaggerTag("Provides authentication endpoints including login, token refresh, and token introspection.")]
 public class AuthController : ControllerBase
 {
     private readonly IConfiguration _configuration;

--- a/rag-auth-service/Models/AuthModels.cs
+++ b/rag-auth-service/Models/AuthModels.cs
@@ -1,7 +1,18 @@
+using Swashbuckle.AspNetCore.Annotations;
+
 namespace RagAuthService.Models;
 
+[SwaggerSchema(Description = "Login request containing user credentials.")]
 public record LoginRequest(string Email, string Password);
+
+[SwaggerSchema(Description = "JWT tokens returned after successful authentication.")]
 public record TokenResponse(string AccessToken, string RefreshToken, int ExpiresIn);
+
+[SwaggerSchema(Description = "Request to obtain new tokens using a refresh token.")]
 public record RefreshRequest(string RefreshToken);
+
+[SwaggerSchema(Description = "Request to verify the validity of a token.")]
 public record IntrospectRequest(string Token);
+
+[SwaggerSchema(Description = "User record retrieved from the authentication database.")]
 public record User(int Id, string Email, string PasswordHash);

--- a/rag-auth-service/Program.cs
+++ b/rag-auth-service/Program.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
+using Swashbuckle.AspNetCore.Annotations;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,7 +14,10 @@ builder.Services.AddSingleton(new RagAuthService.TokenService(jwtSecret));
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.EnableAnnotations();
+});
 
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>

--- a/rag-web-service/Controllers/PromptsController.cs
+++ b/rag-web-service/Controllers/PromptsController.cs
@@ -2,11 +2,13 @@ using MassTransit;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using RagWebService.Models;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace RagWebService.Controllers;
 
 [ApiController]
 [Route("prompts")]
+[SwaggerTag("Handles submission of prompts and retrieval of generated results.")]
 public class PromptsController : ControllerBase
 {
     private readonly IPublishEndpoint _publisher;

--- a/rag-web-service/Models/PromptRequest.cs
+++ b/rag-web-service/Models/PromptRequest.cs
@@ -1,3 +1,6 @@
+using Swashbuckle.AspNetCore.Annotations;
+
 namespace RagWebService.Models;
 
+[SwaggerSchema(Description = "Request payload for submitting a prompt.")]
 public record PromptRequest(string Prompt);

--- a/rag-web-service/Program.cs
+++ b/rag-web-service/Program.cs
@@ -2,6 +2,7 @@ using System.Text;
 using MassTransit;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
+using Swashbuckle.AspNetCore.Annotations;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -12,7 +13,10 @@ var brokerUrl = configuration["MESSAGE_BROKER_URL"] ?? throw new InvalidOperatio
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.EnableAnnotations();
+});
 
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>


### PR DESCRIPTION
## Summary
- describe authentication and prompt controllers for Swagger UI
- document request and response models with Swagger schema annotations
- enable Swagger annotations in both services

## Testing
- `dotnet build rag-web-service/RagWebService.csproj` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68adf03c19688321b2f5a02bc7d62b3f