### PR TITLE
docs: add swagger descriptions

### DIFF
--- a/rag-auth-service/Controllers/AuthController.cs
+++ b/rag-auth-service/Controllers/AuthController.cs
@@ -4,11 +4,13 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using Npgsql;
 using RagAuthService.Models;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace RagAuthService.Controllers;
 
 [ApiController]
 [Route("auth")]
+[SwaggerTag("Provides authentication endpoints including login, token refresh, and token introspection.")]
 public class AuthController : ControllerBase
 {
     private readonly IConfiguration _configuration;
@@ -21,6 +23,7 @@ public class AuthController : ControllerBase
     }
 
     [HttpPost("login")]
+    [SwaggerOperation(Summary = "Authenticate user", Description = "Verifies credentials and returns access and refresh tokens.")]
     public async Task<IActionResult> Login([FromBody] LoginRequest request)
     {
         var connString = _configuration["MAIN_DB_URL"]!;
@@ -44,6 +47,7 @@ public class AuthController : ControllerBase
     }
 
     [HttpPost("refresh")]
+    [SwaggerOperation(Summary = "Refresh tokens", Description = "Generates new access and refresh tokens using a valid refresh token.")]
     public IActionResult Refresh([FromBody] RefreshRequest request)
     {
         var principal = _tokenService.ValidateToken(request.RefreshToken);
@@ -65,6 +69,7 @@ public class AuthController : ControllerBase
     }
 
     [HttpPost("introspect")]
+    [SwaggerOperation(Summary = "Introspect token", Description = "Validates a token and returns its activity and claims.")]
     public IActionResult Introspect([FromBody] IntrospectRequest request)
     {
         var principal = _tokenService.ValidateToken(request.Token, validateLifetime: false);

--- a/rag-auth-service/Models/AuthModels.cs
+++ b/rag-auth-service/Models/AuthModels.cs
@@ -1,7 +1,18 @@
+using Swashbuckle.AspNetCore.Annotations;
+
 namespace RagAuthService.Models;
 
+[SwaggerSchema(Description = "Login request containing user credentials.")]
 public record LoginRequest(string Email, string Password);
+
+[SwaggerSchema(Description = "JWT tokens returned after successful authentication.")]
 public record TokenResponse(string AccessToken, string RefreshToken, int ExpiresIn);
+
+[SwaggerSchema(Description = "Request to obtain new tokens using a refresh token.")]
 public record RefreshRequest(string RefreshToken);
+
+[SwaggerSchema(Description = "Request to verify the validity of a token.")]
 public record IntrospectRequest(string Token);
+
+[SwaggerSchema(Description = "User record retrieved from the authentication database.")]
 public record User(int Id, string Email, string PasswordHash);

--- a/rag-auth-service/Program.cs
+++ b/rag-auth-service/Program.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
+using Swashbuckle.AspNetCore.Annotations;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,7 +14,10 @@ builder.Services.AddSingleton(new RagAuthService.TokenService(jwtSecret));
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.EnableAnnotations();
+});
 
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>

--- a/rag-auth-service/RagAuthService.csproj
+++ b/rag-auth-service/RagAuthService.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.19" />
     <PackageReference Include="Npgsql" Version="8.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
   </ItemGroup>
 
 </Project>

--- a/rag-web-service/Controllers/PromptsController.cs
+++ b/rag-web-service/Controllers/PromptsController.cs
@@ -2,11 +2,13 @@ using MassTransit;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using RagWebService.Models;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace RagWebService.Controllers;
 
 [ApiController]
 [Route("prompts")]
+[SwaggerTag("Handles submission of prompts and retrieval of generated results.")]
 public class PromptsController : ControllerBase
 {
     private readonly IPublishEndpoint _publisher;
@@ -18,6 +20,7 @@ public class PromptsController : ControllerBase
 
     [HttpPost]
     [Authorize]
+    [SwaggerOperation(Summary = "Submit a prompt", Description = "Queues a prompt for processing and returns a task identifier.")]
     public async Task<IActionResult> SubmitPrompt([FromBody] PromptRequest request)
     {
         var taskId = Guid.NewGuid().ToString();
@@ -27,6 +30,7 @@ public class PromptsController : ControllerBase
 
     [HttpGet("{id}")]
     [Authorize]
+    [SwaggerOperation(Summary = "Get prompt result", Description = "Retrieves the generated result for the specified task id.")]
     public IActionResult GetResult(string id)
     {
         // Placeholder for result retrieval logic

--- a/rag-web-service/Models/PromptRequest.cs
+++ b/rag-web-service/Models/PromptRequest.cs
@@ -1,3 +1,6 @@
+using Swashbuckle.AspNetCore.Annotations;
+
 namespace RagWebService.Models;
 
+[SwaggerSchema(Description = "Request payload for submitting a prompt.")]
 public record PromptRequest(string Prompt);

--- a/rag-web-service/Program.cs
+++ b/rag-web-service/Program.cs
@@ -2,6 +2,7 @@ using System.Text;
 using MassTransit;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
+using Swashbuckle.AspNetCore.Annotations;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -12,7 +13,10 @@ var brokerUrl = configuration["MESSAGE_BROKER_URL"] ?? throw new InvalidOperatio
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.EnableAnnotations();
+});
 
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>

--- a/rag-web-service/RagWebService.csproj
+++ b/rag-web-service/RagWebService.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.19" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
     <PackageReference Include="MassTransit" Version="8.2.4" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.4" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- describe authentication and prompt controllers for Swagger UI
- document request and response models with Swagger schema annotations
- enable Swagger annotations in both services
- add Swagger Operation summaries for controller methods

## Testing
- `dotnet build rag-auth-service/RagAuthService.csproj`
- `dotnet build rag-web-service/RagWebService.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68adf03c19688321b2f5a02bc7d62b3f