### PR TITLE
feat: add background worker service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,23 @@ services:
     networks:
       - rag-net
 
+  rag-background-worker:
+    build: ./rag-background-worker
+    env_file: .env
+    environment:
+      - MESSAGE_BROKER_URL=${MESSAGE_BROKER_URL}
+      - DATA_CACHE_URL=${DATA_CACHE_URL}
+      - VECTOR_DB_URL=${VECTOR_DB_URL}
+      - MAIN_DB_URL=${MAIN_DB_URL}
+      - AI_HOST_URL=${AI_HOST_URL}
+    depends_on:
+      - rag-message-broker
+      - rag-data-cache
+      - rag-vector-db
+      - rag-main-db
+    networks:
+      - rag-net
+
 volumes:
   db-data:
   vector-data:

--- a/rag-background-worker/Dockerfile
+++ b/rag-background-worker/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/dotnet/runtime:8.0 AS base
+WORKDIR /app
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["RagBackgroundWorker.csproj", "./"]
+RUN dotnet restore "RagBackgroundWorker.csproj"
+COPY . .
+RUN dotnet publish "RagBackgroundWorker.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "RagBackgroundWorker.dll"]

--- a/rag-background-worker/Program.cs
+++ b/rag-background-worker/Program.cs
@@ -1,0 +1,36 @@
+using MassTransit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using StackExchange.Redis;
+using RagBackgroundWorker;
+
+IHost host = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(args)
+    .ConfigureServices((context, services) =>
+    {
+        var configuration = context.Configuration;
+
+        var brokerUrl = configuration["MESSAGE_BROKER_URL"] ?? throw new InvalidOperationException("MESSAGE_BROKER_URL not configured");
+        var cacheUrl = configuration["DATA_CACHE_URL"] ?? throw new InvalidOperationException("DATA_CACHE_URL not configured");
+        var vectorDbUrl = configuration["VECTOR_DB_URL"] ?? throw new InvalidOperationException("VECTOR_DB_URL not configured");
+        var mainDbUrl = configuration["MAIN_DB_URL"] ?? throw new InvalidOperationException("MAIN_DB_URL not configured");
+        var aiHostUrl = configuration["AI_HOST_URL"] ?? throw new InvalidOperationException("AI_HOST_URL not configured");
+
+        services.AddSingleton<IConnectionMultiplexer>(_ => ConnectionMultiplexer.Connect(cacheUrl));
+        services.AddSingleton(_ => new NpgsqlConnection(mainDbUrl));
+        services.AddHttpClient("vectorDb", c => { c.BaseAddress = new Uri(vectorDbUrl); });
+        services.AddHttpClient("aiHost", c => { c.BaseAddress = new Uri(aiHostUrl); });
+
+        services.AddMassTransit(x =>
+        {
+            x.AddConsumer<PromptConsumer>();
+            x.UsingRabbitMq((context, cfg) =>
+            {
+                cfg.Host(brokerUrl);
+                cfg.ConfigureEndpoints(context);
+            });
+        });
+    })
+    .Build();
+
+await host.RunAsync();

--- a/rag-background-worker/PromptConsumer.cs
+++ b/rag-background-worker/PromptConsumer.cs
@@ -1,0 +1,30 @@
+using MassTransit;
+using Npgsql;
+using StackExchange.Redis;
+
+namespace RagBackgroundWorker;
+
+public class PromptConsumer : IConsumer<PromptMessage>
+{
+    private readonly IConnectionMultiplexer _cache;
+    private readonly NpgsqlConnection _db;
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public PromptConsumer(IConnectionMultiplexer cache, NpgsqlConnection db, IHttpClientFactory httpClientFactory)
+    {
+        _cache = cache;
+        _db = db;
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task Consume(ConsumeContext<PromptMessage> context)
+    {
+        var taskId = context.Message.TaskId;
+        var prompt = context.Message.Prompt;
+
+        Console.WriteLine($"Processing task {taskId} with prompt '{prompt}'");
+
+        // TODO: Check Redis/Qdrant/PostgreSQL, forward to AI host, and store responses
+        await Task.CompletedTask;
+    }
+}

--- a/rag-background-worker/PromptMessage.cs
+++ b/rag-background-worker/PromptMessage.cs
@@ -1,0 +1,3 @@
+namespace RagBackgroundWorker;
+
+public record PromptMessage(string TaskId, string Prompt);

--- a/rag-background-worker/RagBackgroundWorker.csproj
+++ b/rag-background-worker/RagBackgroundWorker.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MassTransit" Version="8.2.4" />
+    <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.4" />
+    <PackageReference Include="Npgsql" Version="8.0.3" />
+    <PackageReference Include="StackExchange.Redis" Version="2.7.27" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add .NET background worker project that consumes prompt jobs
- wire up dependencies for Redis, PostgreSQL, Qdrant, and AI host
- register background worker in docker-compose

## Testing
- `dotnet build rag-background-worker/RagBackgroundWorker.csproj`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adf69f84ac8321b4af361ef970cbf0