### PR TITLE
Add .dockerignore to remaining services

### DIFF
--- a/rag-background-worker/.dockerignore
+++ b/rag-background-worker/.dockerignore
@@ -1,0 +1,8 @@
+bin/
+obj/
+Dockerfile
+*.user
+*.rsproj
+*.vcxproj
+*.suo
+*.swp

--- a/rag-web-service/.dockerignore
+++ b/rag-web-service/.dockerignore
@@ -1,0 +1,8 @@
+bin/
+obj/
+Dockerfile
+*.user
+*.rsproj
+*.vcxproj
+*.suo
+*.swp


### PR DESCRIPTION
## Summary
- add `.dockerignore` to rag-background-worker to ignore build artifacts and project files
- add `.dockerignore` to rag-web-service to keep Docker build context lean

## Testing
- `dotnet build rag-background-worker` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0d0e9d9883219f4ac6b7b967b22e