### PR TITLE
Implement background worker orchestration and result retrieval

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,8 @@ services:
       - MESSAGE_BROKER_URL=${MESSAGE_BROKER_URL}
       - AUTH_SERVICE_URL=${AUTH_SERVICE_URL}
       - JWT_SECRET=${JWT_SECRET}
+      - DATA_CACHE_URL=${DATA_CACHE_URL}
+      - MAIN_DB_URL=${MAIN_DB_URL}
     depends_on:
       - rag-message-broker
       - rag-auth-service

--- a/rag-background-worker/PromptConsumer.cs
+++ b/rag-background-worker/PromptConsumer.cs
@@ -1,6 +1,7 @@
 using MassTransit;
 using Npgsql;
 using StackExchange.Redis;
+using System.Net.Http.Json;
 
 namespace RagBackgroundWorker;
 
@@ -23,8 +24,71 @@ public class PromptConsumer : IConsumer<PromptMessage>
         var prompt = context.Message.Prompt;
 
         Console.WriteLine($"Processing task {taskId} with prompt '{prompt}'");
+        var db = _cache.GetDatabase();
 
-        // TODO: Check Redis/Qdrant/PostgreSQL, forward to AI host, and store responses
-        await Task.CompletedTask;
+        // 1. Check if we already have a cached response for this task
+        var responseKey = $"response:{taskId}";
+        var cachedResponse = await db.StringGetAsync(responseKey);
+        if (!cachedResponse.IsNullOrEmpty)
+        {
+            Console.WriteLine($"Cached response found for task {taskId}");
+            return;
+        }
+
+        // 2. Retrieve vector context, using Redis cache when possible
+        var vectorKey = $"vector:{prompt}";
+        string vectorContext;
+        var cachedVector = await db.StringGetAsync(vectorKey);
+        if (!cachedVector.IsNullOrEmpty)
+        {
+            vectorContext = cachedVector!
+                .ToString();
+        }
+        else
+        {
+            var vectorClient = _httpClientFactory.CreateClient("vectorDb");
+            var vectorResp = await vectorClient.GetAsync($"/search?text={Uri.EscapeDataString(prompt)}");
+            vectorResp.EnsureSuccessStatusCode();
+            vectorContext = await vectorResp.Content.ReadAsStringAsync();
+            await db.StringSetAsync(vectorKey, vectorContext);
+        }
+
+        // 3. Retrieve additional user data from PostgreSQL (cached in Redis)
+        var userKey = $"user:{taskId}";
+        string userContext;
+        var cachedUser = await db.StringGetAsync(userKey);
+        if (!cachedUser.IsNullOrEmpty)
+        {
+            userContext = cachedUser!;
+        }
+        else
+        {
+            await using var userConn = new NpgsqlConnection(_db.ConnectionString);
+            await userConn.OpenAsync();
+            using var cmd = new NpgsqlCommand("SELECT data FROM user_data LIMIT 1", userConn);
+            var result = await cmd.ExecuteScalarAsync();
+            userContext = result?.ToString() ?? string.Empty;
+            await db.StringSetAsync(userKey, userContext);
+        }
+
+        // 4. Forward augmented prompt to the AI host
+        var augmentedPrompt = $"{prompt}\n{vectorContext}\n{userContext}";
+        var aiClient = _httpClientFactory.CreateClient("aiHost");
+        var aiResp = await aiClient.PostAsJsonAsync("/generate", new { prompt = augmentedPrompt });
+        aiResp.EnsureSuccessStatusCode();
+        var generated = await aiResp.Content.ReadAsStringAsync();
+
+        // 5. Store response in PostgreSQL and cache
+        await using (var conn = new NpgsqlConnection(_db.ConnectionString))
+        {
+            await conn.OpenAsync();
+            using var insert = new NpgsqlCommand("INSERT INTO responses(task_id, prompt, response) VALUES (@taskId, @prompt, @response)", conn);
+            insert.Parameters.AddWithValue("taskId", taskId);
+            insert.Parameters.AddWithValue("prompt", prompt);
+            insert.Parameters.AddWithValue("response", generated);
+            await insert.ExecuteNonQueryAsync();
+        }
+
+        await db.StringSetAsync(responseKey, generated);
     }
 }

--- a/rag-web-service/Controllers/PromptsController.cs
+++ b/rag-web-service/Controllers/PromptsController.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using RagWebService.Models;
 using Swashbuckle.AspNetCore.Annotations;
+using StackExchange.Redis;
+using Npgsql;
 
 namespace RagWebService.Controllers;
 
@@ -12,10 +14,14 @@ namespace RagWebService.Controllers;
 public class PromptsController : ControllerBase
 {
     private readonly IPublishEndpoint _publisher;
+    private readonly IConnectionMultiplexer _cache;
+    private readonly NpgsqlConnection _db;
 
-    public PromptsController(IPublishEndpoint publisher)
+    public PromptsController(IPublishEndpoint publisher, IConnectionMultiplexer cache, NpgsqlConnection db)
     {
         _publisher = publisher;
+        _cache = cache;
+        _db = db;
     }
 
     [HttpPost]
@@ -31,9 +37,28 @@ public class PromptsController : ControllerBase
     [HttpGet("{id}")]
     [Authorize]
     [SwaggerOperation(Summary = "Get prompt result", Description = "Retrieves the generated result for the specified task id.")]
-    public IActionResult GetResult(string id)
+    public async Task<IActionResult> GetResult(string id)
     {
-        // Placeholder for result retrieval logic
-        return NotFound();
+        var cacheDb = _cache.GetDatabase();
+        var cacheKey = $"response:{id}";
+        var cached = await cacheDb.StringGetAsync(cacheKey);
+        if (!cached.IsNullOrEmpty)
+        {
+            return Ok(new { response = cached.ToString() });
+        }
+
+        await using var conn = new NpgsqlConnection(_db.ConnectionString);
+        await conn.OpenAsync();
+        using var cmd = new NpgsqlCommand("SELECT response FROM responses WHERE task_id = @id", conn);
+        cmd.Parameters.AddWithValue("id", id);
+        var result = await cmd.ExecuteScalarAsync();
+        if (result == null)
+        {
+            return NotFound();
+        }
+
+        var response = result.ToString() ?? string.Empty;
+        await cacheDb.StringSetAsync(cacheKey, response);
+        return Ok(new { response });
     }
 }

--- a/rag-web-service/Program.cs
+++ b/rag-web-service/Program.cs
@@ -3,6 +3,8 @@ using MassTransit;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using Swashbuckle.AspNetCore.Annotations;
+using StackExchange.Redis;
+using Npgsql;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -10,6 +12,8 @@ var configuration = builder.Configuration;
 
 var jwtSecret = configuration["JWT_SECRET"] ?? throw new InvalidOperationException("JWT_SECRET not configured");
 var brokerUrl = configuration["MESSAGE_BROKER_URL"] ?? throw new InvalidOperationException("MESSAGE_BROKER_URL not configured");
+var cacheUrl = configuration["DATA_CACHE_URL"] ?? throw new InvalidOperationException("DATA_CACHE_URL not configured");
+var mainDbUrl = configuration["MAIN_DB_URL"] ?? throw new InvalidOperationException("MAIN_DB_URL not configured");
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
@@ -40,6 +44,9 @@ builder.Services.AddMassTransit(x =>
 });
 
 builder.Services.AddAuthorization();
+
+builder.Services.AddSingleton<IConnectionMultiplexer>(_ => ConnectionMultiplexer.Connect(cacheUrl));
+builder.Services.AddSingleton(_ => new NpgsqlConnection(mainDbUrl));
 
 var app = builder.Build();
 

--- a/rag-web-service/RagWebService.csproj
+++ b/rag-web-service/RagWebService.csproj
@@ -11,5 +11,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
     <PackageReference Include="MassTransit" Version="8.2.4" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.4" />
+    <PackageReference Include="Npgsql" Version="8.0.3" />
+    <PackageReference Include="StackExchange.Redis" Version="2.7.27" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Expand background worker to orchestrate cache lookups, vector and database queries, AI host calls, and result persistence
- Add web service result retrieval using Redis and PostgreSQL
- Wire up cache and database configuration across services

## Testing
- `dotnet build rag-background-worker/RagBackgroundWorker.csproj`
- `dotnet build rag-web-service/RagWebService.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68af427075388321b20987bd9779bca3